### PR TITLE
Add case where filter ignores an old message to cloudlog (debug)

### DIFF
--- a/rednose/SConscript
+++ b/rednose/SConscript
@@ -1,4 +1,4 @@
-Import('env', 'envCython', 'arch', 'rednose_config')
+Import('env', 'envCython', 'arch', 'rednose_config', 'common')
 
 generated_folder = rednose_config['generated_folder']
 
@@ -34,7 +34,7 @@ libkf = env.SharedLibrary(f'{generated_folder}/libkf', lib_target)
 
 lenv = envCython.Clone()
 lenv["LINKFLAGS"] += [libkf[0].get_labspath()]
-ekf_sym_so = lenv.Program('#rednose/helpers/ekf_sym_pyx.so', [ekf_sym_pyx, ekf_sym_cc, common_ekf])
+ekf_sym_so = lenv.Program('#rednose/helpers/ekf_sym_pyx.so', [ekf_sym_pyx, ekf_sym_cc, common_ekf], LIBS=['zmq', common])
 lenv.Depends(ekf_sym_so, libkf)
 
 Export('libkf')

--- a/rednose/helpers/ekf_sym.cc
+++ b/rednose/helpers/ekf_sym.cc
@@ -1,4 +1,5 @@
 #include "ekf_sym.h"
+#include "logger/logger.h"
 
 using namespace EKFS;
 using namespace Eigen;
@@ -88,7 +89,7 @@ std::optional<Estimate> EKFSym::predict_and_update_batch(double t, int kind, std
   std::deque<Observation> rewound;
   if (!std::isnan(this->filter_time) && t < this->filter_time) {
     if (this->rewind_t.empty() || t < this->rewind_t.front() || t < this->rewind_t.back() - this->max_rewind_age) {
-      std::cout << "observation too old at " << t << " with filter at " << this->filter_time << ", ignoring" << std::endl;
+      LOGD("observation too old at %d with filter at %d, ignoring!", t, this->filter_time);
       return std::nullopt;
     }
     rewound = this->rewind(t);

--- a/rednose/helpers/ekf_sym_pyx.pyx
+++ b/rednose/helpers/ekf_sym_pyx.pyx
@@ -17,6 +17,8 @@ cdef extern from "<optional>" namespace "std" nogil:
     bool has_value()
     T& value()
 
+cdef extern from "logger/logger.h":
+  pass
 cdef extern from "rednose/helpers/ekf_sym.h" namespace "EKFS":
   cdef cppclass MapVectorXd "Eigen::Map<Eigen::VectorXd>":
     MapVectorXd(double*, int)


### PR DESCRIPTION
This is needed to understand how many messages the filter drops (which should ideally be 0). 