### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from ubuntu:20.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y libzmq3-dev capnproto libcapnp-dev clang wget git autoconf libtool curl make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl libeigen3-dev
@@ -8,7 +8,6 @@ ENV PATH="/root/.pyenv/bin:/root/.pyenv/shims:${PATH}"
 RUN pyenv install 3.8.5
 RUN pyenv global 3.8.5
 RUN pyenv rehash
-RUN pip3 install scons==4.1.0.post1 pre-commit==2.10.1 pylint==2.7.1 Cython==0.29.22
 
 WORKDIR /project
 
@@ -16,5 +15,6 @@ ENV PYTHONPATH=/project
 
 COPY . .
 RUN rm -rf .git
+RUN pip3 install --no-cache-dir -r requirements.txt
 RUN python3 setup.py install
 RUN scons -c && scons -j$(nproc)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+sympy
+numpy
+scipy
+tqdm
+cffi
+scons==4.1.0.post1
+pre-commit==2.10.1
+pylint==2.7.1
+Cython==0.29.22


### PR DESCRIPTION
using --no-cache-dir flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>