### PR TITLE
Use numpy instead of numpy-stubs in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     rev: v1.4.0
     hooks:
     -   id: mypy
-        additional_dependencies: ['git+https://github.com/numpy/numpy-stubs']
+        additional_dependencies: ['numpy']
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.2
     hooks:


### PR DESCRIPTION
numpy-stubs is deprecated. This fixes pre-commit errors.