### PR TITLE
Use std::move for Efficient Observation Rewind

### DIFF
--- a/rednose/helpers/ekf_sym.cc
+++ b/rednose/helpers/ekf_sym.cc
@@ -127,7 +127,7 @@ std::deque<Observation> EKFSym::rewind(double t) {
 
   // rewind observations until t is after previous observation
   while (this->rewind_t.back() > t) {
-    rewound.push_front(this->rewind_obscache.back());
+    rewound.push_front(std::move(this->rewind_obscache.back()));
     this->rewind_t.pop_back();
     this->rewind_states.pop_back();
     this->rewind_obscache.pop_back();


### PR DESCRIPTION
This change optimizes the EKFSym::rewind function by using std::move when appending observations to the rewound deque through void push_front( T&& value ); as outlined in [cppreference](https://en.cppreference.com/w/cpp/container/deque/push_front). 

This reduces memory overhead and improves performance.